### PR TITLE
ci: enable attestations on pypi publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,3 +54,5 @@ jobs:
       - name: Publish package to PyPI
         if: env.PREVIOUS_REVISION != env.REVISION
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true


### PR DESCRIPTION
Waiting for https://github.com/rhysd/actionlint/pull/446 to be merged and released.